### PR TITLE
Provide access to character metrics via the adobe glyph name

### DIFF
--- a/lib/afm.rb
+++ b/lib/afm.rb
@@ -99,5 +99,13 @@ module AFM
       end
       @char_metrics[glyph]
     end
+
+    # Get metrics for character, looking it up by the adobe name. Takes a string.
+    #
+    #   metrics_for_name(:A)
+    #   => {:charcode=>174, :wx=>556, :boundingbox=>[14, 0, 536, 691]}
+    def metrics_for_name(name)
+      @char_metrics[name.to_s]
+    end
   end
 end


### PR DESCRIPTION
Provide access to character metrics via the adobe glyph name
- I'm experimenting with using this gem in pdf-reader
- To support arbitrary encodings, I need to be able to look up 
  the metrics for any glyph, not just latin1
- The method name feels a little unwieldy, maybe someone else
  can think of something better
