### PR TITLE
fix AFM#metrics_for to work across ruby 1.8, 1.9 and 2.0

### DIFF
--- a/lib/afm.rb
+++ b/lib/afm.rb
@@ -95,7 +95,7 @@ module AFM
       glyph = if (char.kind_of?(Integer))
         ISO_LATIN1_ENCODING[char]
       else
-        ISO_LATIN1_ENCODING[char[0]]
+        ISO_LATIN1_ENCODING[char.unpack("C*").first]
       end
       @char_metrics[glyph]
     end


### PR DESCRIPTION
- on 1.8 String#[] returns the character code at that position as an int
- on 1.9+ String#[] returns a single character string
